### PR TITLE
docs: add additional information part in the question issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -10,6 +10,13 @@ body:
       description: Please write your question/discussion about this project here
     validations:
       required: true
+  - type: textarea
+    id: extrainfo
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this issue?
+    validations:
+      required: false
   - type: checkboxes
     id: coc
     attributes:


### PR DESCRIPTION
Things added/changed:

- Add additional information part in
  the question issue form.
